### PR TITLE
ESP32: move the ipv4_info variable where its used

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -203,7 +203,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         for (esp_netif_t * ifa = netif; ifa != NULL; ifa = esp_netif_next(ifa))
         {
             NetworkInterface * ifp = new NetworkInterface();
-            esp_netif_ip_info_t ipv4_info;
             uint8_t addressSize = 0;
             Platform::CopyString(ifp->Name, esp_netif_get_ifkey(ifa));
             ifp->name          = CharSpan::fromCharString(ifp->Name);
@@ -236,6 +235,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
                 ChipLogError(DeviceLayer, "Failed to get network hardware address");
             }
 #ifndef CONFIG_DISABLE_IPV4
+            esp_netif_ip_info_t ipv4_info;
             if (esp_netif_get_ip_info(ifa, &ipv4_info) == ESP_OK)
             {
                 memcpy(ifp->Ipv4AddressesBuffer[0], &(ipv4_info.ip.addr), kMaxIPv4AddrSize);


### PR DESCRIPTION
#### Summary
unused error warning when app is build with ipv6-only config

warning in ci: https://github.com/project-chip/connectedhomeip/actions/runs/16652181524/job/47127606834#step:13:2391

```
INFO    ../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/DiagnosticDataProviderImpl.cpp: In member function 'virtual CHIP_ERROR chip::DeviceLayer::DiagnosticDataProviderImpl::GetNetworkInterfaces(chip::DeviceLayer::NetworkInterface**)':
INFO    ../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/DiagnosticDataProviderImpl.cpp:206:33: warning: unused variable 'ipv4_info' [-Wunused-variable]
INFO      206 |             esp_netif_ip_info_t ipv4_info;
INFO          |                                 ^~~~~~~~~
INFO    At global scope:
INFO    cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
``` 

#### Related issues

#### Testing
- CI should be green and no warning should appear in the CI
- tested locally and warning disappeared

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
